### PR TITLE
Fix HSET to support multiple fields

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -97,7 +97,7 @@ Command Command::CmdPool[AvailableCommands] = {
     {Hmget,             "hmget",            3,  MaxArgs,   Read},
     {Hmset,             "hmset",            4,  MaxArgs,   Write},
     {Hscan,             "hscan",            3,  7,         Read},
-    {Hset,              "hset",             4,  4,         Write},
+    {Hset,              "hset",             4,  MaxArgs,   Write},
     {Hsetnx,            "hsetnx",           4,  4,         Write},
     {Hstrlen,           "hstrlen",          3,  3,         Read},
     {Hvals,             "hvals",            2,  2,         Read},


### PR DESCRIPTION
- From Redis 4.0.0, HSET is recommended for multiple fields and HMSET is deprecated
- Omitted test case because it would fail if it runs on lower version (<=3.x)
