### PR TITLE
script load fix

### DIFF
--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -617,6 +617,9 @@ bool Handler::preHandleRequest(Request* req, const String& key)
             req->setType(Command::ScriptLoad);
             req->follow(req);
             while (Server* serv = sp->iter(cursor)) {
+                if (serv->fail()) {
+                    continue;
+                }
                 RequestPtr r = RequestAlloc::create();
                 r->follow(req);
                 ConnectConnection* s = getConnectConnection(r, serv);


### PR DESCRIPTION
When a server is in failed state, script load command should skip that server as well