### PR TITLE
Add self node in first cluster node response

### DIFF
--- a/src/ClusterServerPool.cpp
+++ b/src/ClusterServerPool.cpp
@@ -113,9 +113,7 @@ void ClusterServerPool::handleResponse(Handler* h, ConnectConnection* s, Request
             auto it = mServs.find(addr);
             Server* serv = it == mServs.end() ? nullptr : it->second;
             if (!serv) {
-                if (strstr(p.flags().data(), "myself")) {
-                    serv = s->server();
-                } else if (const char* t = strchr(p.addr().data(), '@')) {
+                if (const char* t = strchr(p.addr().data(), '@')) {
                     addr = String(p.addr().data(), t - p.addr().data());
                     it = mServs.find(addr);
                     serv = it == mServs.end() ? nullptr : it->second;


### PR DESCRIPTION
Recently we faced an issue on production where predixy was throwing "MOVED" error just after the process started. After debugging found that

"Info" command output - Just after predixy got healthy (health check using ping command)
`# Servers
Server:prod-adserver.xoptuc.clustercfg.apse1.cache.amazonaws.com:6379
Role:master
Group:abbff3be959032ba777a295f9d4210a281841d51
DC:
CurrentIsFail:0
Connections:5
Connect:5
Requests:249
Responses:249
SendBytes:25169
RecvBytes:4109

Server:192.168.5.176:6379
Role:slave
Group:abbff3be959032ba777a295f9d4210a281841d51
DC:
CurrentIsFail:0
Connections:5
Connect:5
Requests:47
Responses:47
SendBytes:2072`


And after 10-30 seconds (refresh interval is 30) after predixy got healthy
`# Servers
Server:prod-adserver.xoptuc.clustercfg.apse1.cache.amazonaws.com:6379
Role:master
Group:abbff3be959032ba777a295f9d4210a281841d51
DC:
CurrentIsFail:0
Connections:5
Connect:5
Requests:249
Responses:249
SendBytes:25169
RecvBytes:4109

Server:192.168.5.176:6379
Role:slave
Group:abbff3be959032ba777a295f9d4210a281841d51
DC:
CurrentIsFail:0
Connections:5
Connect:5
Requests:47
Responses:47
SendBytes:2072
RecvBytes:962

Server:192.168.5.46:6379
Role:master
Group:abbff3be959032ba777a295f9d4210a281841d51
DC:
CurrentIsFail:0
Connections:5
Connect:5
Requests:190
Responses:125
SendBytes:10775
RecvBytes:1409`

After checking the code and debug logs found that "self" replica is not getting added in the pool in the first attempt. It gets added in the second call of "cluster nodes".