### PR TITLE
Fix ERR no server connection avaliable

### DIFF
--- a/src/ServerGroup.cpp
+++ b/src/ServerGroup.cpp
@@ -49,14 +49,16 @@ Server* ServerGroup::getServer(Handler* h, Request* req) const
     Server* serv = nullptr;
     if (req->requireWrite()) {
         int cnt = mServs.size();
-        for (int i = 0; i < cnt; ++i) {
+        for (int i = cnt-1; i >= 0; --i) {
             Server* s = mServs[i];
             if (!s->online()) {
                 continue;
             }
             if (s->role() == Server::Master) {
                 serv = s;
-                break;
+                if (!s->fail()){
+                    break;
+                }
             }
         }
     } else if (auto dataCenter = mPool->proxy()->dataCenter()) {


### PR DESCRIPTION

Fixes #120 
when use in k8s, may got "ERR no server connection avaliable".
when Group is 3742d2abb027994f3b2bd2f11a5601ed42987db9,  we need chose 10.244.1.41:6379 not 10.244.1.17 
```
# Servers
Server:redis-cache-cluster:6379
Role:master
Group:8f283c20c1b2e46e112fd6bc13f73fb082395ae5
DC:
CurrentIsFail:0
Connections:4
Connect:12
Requests:1170
Responses:1149
SendBytes:66099
RecvBytes:243599

Server:10.244.0.9:6379
Role:master
Group:8f283c20c1b2e46e112fd6bc13f73fb082395ae5
DC:
CurrentIsFail:0
Connections:4
Connect:4
Requests:1185
Responses:1099
SendBytes:56651
RecvBytes:255376

Server:10.244.1.17:6379
Role:master
Group:3742d2abb027994f3b2bd2f11a5601ed42987db9
DC:
CurrentIsFail:1
Connections:4
Connect:160
Requests:1865
Responses:1363
SendBytes:69689
RecvBytes:269368

Server:10.244.3.11:6379
Role:master
Group:20bf9177eec90ac3ba427f163b30755e295f91f2
DC:
CurrentIsFail:0
Connections:4
Connect:4
Requests:2213
Responses:2213
SendBytes:122653
RecvBytes:302124

Server:10.244.2.13:6379
Role:master
Group:1ee394d474aec473687d72dccbfba1c40ffea93c
DC:
CurrentIsFail:1
Connections:4
Connect:321
Requests:922
Responses:240
SendBytes:8992
RecvBytes:126164

Server:10.244.1.21:6379
Role:slave
Group:20bf9177eec90ac3ba427f163b30755e295f91f2
DC:
CurrentIsFail:1
Connections:4
Connect:157
Requests:610
Responses:234
SendBytes:6568
RecvBytes:172364

Server:10.244.2.9:6379
Role:slave
Group:3742d2abb027994f3b2bd2f11a5601ed42987db9
DC:
CurrentIsFail:1
Connections:4
Connect:319
Requests:861
Responses:185
SendBytes:5196
RecvBytes:134955

Server:10.244.2.30:6379
Role:slave
Group:8f283c20c1b2e46e112fd6bc13f73fb082395ae5
DC:
CurrentIsFail:0
Connections:4
Connect:4
Requests:291
Responses:291
SendBytes:8052
RecvBytes:216567

Server:10.244.2.34:6379
Role:slave
Group:3742d2abb027994f3b2bd2f11a5601ed42987db9
DC:
CurrentIsFail:0
Connections:4
Connect:4
Requests:803
Responses:800
SendBytes:45939
RecvBytes:156398

Server:10.244.1.34:6379
Role:slave
Group:20bf9177eec90ac3ba427f163b30755e295f91f2
DC:
CurrentIsFail:0
Connections:4
Connect:4
Requests:41
Responses:41
SendBytes:1052
RecvBytes:25196

Server:10.244.1.41:6379
Role:master
Group:3742d2abb027994f3b2bd2f11a5601ed42987db9
DC:
CurrentIsFail:0
Connections:4
Connect:4
Requests:320
Responses:320
SendBytes:17261
RecvBytes:62966
```