### PR TITLE
fix bug : leak private connections

### DIFF
--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -906,7 +906,7 @@ void Handler::handleResponse(ConnectConnection* s, Request* req, Response* res)
     default:
         break;
     }
-    if (s && !s->isShared()) {
+    if (s && !s->isShared() && res->code() != Response::ServerConnectionClose) {
         if (!c->inTransaction() && !c->inSub(true)) {
             mConnPool[s->server()->id()]->putPrivateConnection(s);
             c->detachConnectConnection();

--- a/src/List.h
+++ b/src/List.h
@@ -91,9 +91,12 @@ public:
         P obj = mHead;
         if (obj) {
             Node* n = node((T*)obj);
-            mHead = n->next(Idx); 
-            if (--mSize == 0) {
-                mTail = nullptr;
+            if (mHead == mTail) {
+                mHead = mTail = nullptr;
+                mSize = 0;
+            } else {
+                mHead = n->next(Idx); 
+                --mSize;
             }
             n->reset(Idx);
         }

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -59,7 +59,8 @@ Response::Response():
 
 Response::Response(GenericCode code):
     mType(Reply::None),
-    mInteger(0)
+    mInteger(0),
+    mCode(code)
 {
     auto r = GenericResponses[code];
     mType = r->mType;

--- a/src/Response.h
+++ b/src/Response.h
@@ -128,6 +128,9 @@ public:
     {
         return mRes;
     }
+    GenericCode code() const {
+        return mCode;
+    }
 private:
     bool getAddr(int& slot, SString<Const::MaxAddrLen>& addr, const char* token) const;
 private:
@@ -135,6 +138,7 @@ private:
     int64_t mInteger;
     Segment mHead; //for mget
     Segment mRes;
+    GenericCode mCode;
 };
 
 typedef List<Response> ResponseList;


### PR DESCRIPTION
Handler::postConnectConnectionEvent() function put idle connection to pool twice. 

pseudocode
```
void Handler::postConnectConnectionEvent()
{
    while (!mPostConnectConns.empty()) {
        ConnectConnection* s = mPostConnectConns.pop_front();
        ......
        if ((!s->good()||(evts & Multiplexor::ErrorEvent)) && s->fd() >= 0){
            ......
            
            // it call putPrivateConnection first time.
            s->close(this);
            if (!s->isShared()) {
                // put pool again
                mConnPool[s->server()->id()]->putPrivateConnection(s);
            }
            ......
        }
    }
}

void ConnectConnection::close(Handler* h)
{
    SendRequestList* reqs[2] = {&mSentRequests, &mSendRequests};
    for (int i = 0; i < 2; ++i) {
        while (!reqs[i]->empty()) {
            auto req = reqs[i]->front();
            h->directResponse(req, Response::ServerConnectionClose, this);
            reqs[i]->pop_front();
        }
    }
    ......
}

void Handler::directResponse(Request* req, Response::GenericCode code, ConnectConnection* s)
{
     ......
                ResponsePtr res = ResponseAlloc::create(code);
                handleResponse(s, req, res);
      ......
}

void Handler::handleResponse(ConnectConnection* s, Request* req, Response* res)
{
    ......

    if (c->send(this, req, res)) {    }

    ......
    if (s && !s->isShared()) {
        if (!c->inTransaction() && !c->inSub(true)) {
            // problem is here
            mConnPool[s->server()->id()]->putPrivateConnection(s);
            c->detachConnectConnection();
            s->detachAcceptConnection();
        }
    }
}
```



**reproduce steps**
- send transaction requests to predixy, about100 QPS : multi, set, set, exec
- change redis timeout to 2 seconds : redis-cli -p 6379 config set timeout 2
- drop redis traffics : sudo iptables -A INPUT -p tcp --dport 6379 -j DROP
- wait 3 seconds
- delete iptable rule : sudo iptables -D INPUT -p tcp --dport 6379 -j DROP
- redis-cli -p 6379 config set timeout 2000

check whether connections are leaking :    
watch -n 1 "netstat -apn | grep 6379 | grep ESTAB  | wc -l"

