### PR TITLE
Fix SCAN cursor overflow in Cluster mode by using 128-bit encoding

### DIFF
--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -841,53 +841,77 @@ void Handler::handleResponse(ConnectConnection* s, Request* req, Response* res)
         }
     } else if (req->type() == Command::Scan && s && res->type() == Reply::Array) {
         SegmentStr<64> str(res->body());
-        if (const char* p = strchr(str.data() + sizeof("*2\r\n$"), '\n')) {
-            // Use 128-bit integer to handle large cursor values (Kvrocks may return cursor close to 64-bit limit)
-            __uint128_t cursor = 0;
-            const char* cursorStr = p + 1;
-            const char* cursorStart = cursorStr;
-            while (*cursorStr >= '0' && *cursorStr <= '9') {
-                cursor = cursor * 10 + (*cursorStr - '0');
-                cursorStr++;
+        // SCAN response format: *2\r\n$<len>\r\n<cursor>\r\n*<count>\r\n...
+        // Skip "*2\r\n$" (5 bytes) and find the first '\n' after the length number
+        // Add boundary check to prevent buffer overflow
+        const char* start = str.data();
+        int len = str.length();
+        if (len >= 5) {
+            const char* end = start + len;
+            const char* p = start + 5;  // Skip "*2\r\n$" (5 bytes, not sizeof which returns 8!)
+            
+            // Find '\n' within buffer boundary (safer than strchr)
+            while (p < end && *p != '\n') {
+                p++;
             }
             
-            // Debug log: cursor received from backend server
-            char serverCursorBuf[64];
-            int serverCursorLen = cursorStr - cursorStart;
-            if (serverCursorLen > 0 && serverCursorLen < 64) {
-                memcpy(serverCursorBuf, cursorStart, serverCursorLen);
-                serverCursorBuf[serverCursorLen] = '\0';
-            } else {
-                strcpy(serverCursorBuf, "0");
-            }
-            
-            auto g = s->server()->group();
-            int currentGroupId = g ? g->id() : -1;
-            
-            if (cursor != 0 || (g = sp->getGroup(g->id() + 1)) != nullptr) {
-                // Use 128-bit integer for left shift, will not overflow
-                cursor <<= Const::ServGroupBits;
-                cursor |= g->id();
-                if ((p = strchr(p, '*')) != nullptr) {
-                    // Convert 128-bit integer to string
-                    char buf[64];  // 128-bit needs at most 39 decimal digits
-                    int n = Util::uint128ToString(cursor, buf);
-                    
-                    // Debug log: cursor to be sent to client
-                    logDebug("h %d SCAN cursor from server: %s, group: %d, cursor to client: %s",
-                            id(), serverCursorBuf, g->id(), buf);
-                    
-                    res->head().fset(nullptr,
-                            "*2\r\n"
-                            "$%d\r\n"
-                            "%s\r\n",
-                            n, buf);
-                    res->body().cut(p - str.data());
+            if (p < end) {  // Found '\n'
+                // Use 128-bit integer to handle large cursor values (Kvrocks may return cursor close to 64-bit limit)
+                __uint128_t cursor = 0;
+                const char* cursorStr = p + 1;
+                const char* cursorStart = cursorStr;
+                
+                // Parse cursor digits within buffer boundary
+                while (cursorStr < end && *cursorStr >= '0' && *cursorStr <= '9') {
+                    cursor = cursor * 10 + (*cursorStr - '0');
+                    cursorStr++;
                 }
-            } else {
-                // Scan completed, return 0 to client
-                logDebug("h %d SCAN cursor from server: %s, group: %d, cursor to client: 0 (scan complete)",
-                        id(), serverCursorBuf, currentGroupId);
+                
+                // Debug log: cursor received from backend server
+                char serverCursorBuf[64];
+                int serverCursorLen = cursorStr - cursorStart;
+                if (serverCursorLen > 0 && serverCursorLen < 64) {
+                    memcpy(serverCursorBuf, cursorStart, serverCursorLen);
+                    serverCursorBuf[serverCursorLen] = '\0';
+                } else {
+                    strcpy(serverCursorBuf, "0");
+                }
+                
+                auto g = s->server()->group();
+                int currentGroupId = g ? g->id() : -1;
+                
+                if (cursor != 0 || (g = sp->getGroup(g->id() + 1)) != nullptr) {
+                    // Use 128-bit integer for left shift, will not overflow
+                    cursor <<= Const::ServGroupBits;
+                    cursor |= g->id();
+                    
+                    // Find '*' within buffer boundary
+                    const char* asteriskPos = p + 1;
+                    while (asteriskPos < end && *asteriskPos != '*') {
+                        asteriskPos++;
+                    }
+                    
+                    if (asteriskPos < end) {  // Found '*'
+                        // Convert 128-bit integer to string
+                        char buf[64];  // 128-bit needs at most 39 decimal digits
+                        int n = Util::uint128ToString(cursor, buf);
+                        
+                        // Debug log: cursor to be sent to client
+                        logDebug("h %d SCAN cursor from server: %s, group: %d, cursor to client: %s",
+                                id(), serverCursorBuf, g->id(), buf);
+                        
+                        res->head().fset(nullptr,
+                                "*2\r\n"
+                                "$%d\r\n"
+                                "%s\r\n",
+                                n, buf);
+                        res->body().cut(asteriskPos - start);
+                    }
+                } else {
+                    // Scan completed, return 0 to client
+                    logDebug("h %d SCAN cursor from server: %s, group: %d, cursor to client: 0 (scan complete)",
+                            id(), serverCursorBuf, currentGroupId);
+                }
             }
         }
     }

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -649,10 +649,24 @@ bool Handler::preHandleRequest(Request* req, const String& key)
     case Command::Scan:
         {
             auto sp = mProxy->serverPool();
-            unsigned long cursor = atol(key.data());
-            int groupIdx = cursor & Const::ServGroupMask;
+            // Use 128-bit integer to handle large cursor values
+            __uint128_t cursor = 0;
+            const char* cursorStr = key.data();
+            // Manually parse string to 128-bit integer
+            while (*cursorStr >= '0' && *cursorStr <= '9') {
+                cursor = cursor * 10 + (*cursorStr - '0');
+                cursorStr++;
+            }
+            
+            // Debug log: cursor received from client
+            char cursorBuf[64];
+            Util::uint128ToString(cursor, cursorBuf);
+            
+            int groupIdx = (unsigned long)(cursor & Const::ServGroupMask);
             auto g = sp->getGroup(groupIdx);
             if (!g) {
+                logDebug("h %d SCAN cursor from client: %s (invalid group %d)",
+                        id(), cursorBuf, groupIdx);
                 directResponse(req, Response::InvalidScanCursor);
                 return true;
             }
@@ -661,12 +675,26 @@ bool Handler::preHandleRequest(Request* req, const String& key)
                 serv = g->getMaster();
             }
             if (!serv) {
+                logDebug("h %d SCAN cursor from client: %s (no server available)",
+                        id(), cursorBuf);
                 directResponse(req, Response::ScanEnd);
                 return true;
             }
             if (ConnectConnection* s = getConnectConnection(req, serv)) {
                 if (cursor != 0) {
-                    req->adjustScanCursor(cursor >> Const::ServGroupBits);
+                    __uint128_t actualCursor = cursor >> Const::ServGroupBits;
+                    
+                    // Debug log: cursor to be sent to backend server
+                    char actualCursorBuf[64];
+                    Util::uint128ToString(actualCursor, actualCursorBuf);
+                    
+                    logDebug("h %d SCAN cursor from client: %s, group: %d, cursor to server: %s",
+                            id(), cursorBuf, groupIdx, actualCursorBuf);
+                    
+                    req->adjustScanCursor(actualCursor);
+                } else {
+                    logDebug("h %d SCAN cursor from client: 0, group: %d, cursor to server: 0",
+                            id(), groupIdx);
                 }
                 handleRequest(req, s);
             } else {
@@ -814,14 +842,41 @@ void Handler::handleResponse(ConnectConnection* s, Request* req, Response* res)
     } else if (req->type() == Command::Scan && s && res->type() == Reply::Array) {
         SegmentStr<64> str(res->body());
         if (const char* p = strchr(str.data() + sizeof("*2\r\n$"), '\n')) {
-            long cursor = atol(p + 1);
+            // Use 128-bit integer to handle large cursor values (Kvrocks may return cursor close to 64-bit limit)
+            __uint128_t cursor = 0;
+            const char* cursorStr = p + 1;
+            const char* cursorStart = cursorStr;
+            while (*cursorStr >= '0' && *cursorStr <= '9') {
+                cursor = cursor * 10 + (*cursorStr - '0');
+                cursorStr++;
+            }
+            
+            // Debug log: cursor received from backend server
+            char serverCursorBuf[64];
+            int serverCursorLen = cursorStr - cursorStart;
+            if (serverCursorLen > 0 && serverCursorLen < 64) {
+                memcpy(serverCursorBuf, cursorStart, serverCursorLen);
+                serverCursorBuf[serverCursorLen] = '\0';
+            } else {
+                strcpy(serverCursorBuf, "0");
+            }
+            
             auto g = s->server()->group();
+            int currentGroupId = g ? g->id() : -1;
+            
             if (cursor != 0 || (g = sp->getGroup(g->id() + 1)) != nullptr) {
+                // Use 128-bit integer for left shift, will not overflow
                 cursor <<= Const::ServGroupBits;
                 cursor |= g->id();
                 if ((p = strchr(p, '*')) != nullptr) {
-                    char buf[32];
-                    int n = snprintf(buf, sizeof(buf), "%ld", cursor);
+                    // Convert 128-bit integer to string
+                    char buf[64];  // 128-bit needs at most 39 decimal digits
+                    int n = Util::uint128ToString(cursor, buf);
+                    
+                    // Debug log: cursor to be sent to client
+                    logDebug("h %d SCAN cursor from server: %s, group: %d, cursor to client: %s",
+                            id(), serverCursorBuf, g->id(), buf);
+                    
                     res->head().fset(nullptr,
                             "*2\r\n"
                             "$%d\r\n"
@@ -829,6 +884,10 @@ void Handler::handleResponse(ConnectConnection* s, Request* req, Response* res)
                             n, buf);
                     res->body().cut(p - str.data());
                 }
+            } else {
+                // Scan completed, return 0 to client
+                logDebug("h %d SCAN cursor from server: %s, group: %d, cursor to client: 0 (scan complete)",
+                        id(), serverCursorBuf, currentGroupId);
             }
         }
     }

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -246,10 +246,10 @@ void Request::setSentinelSlaves(const String& master)
               master.length(), master.length(), master.data());
 }
 
-void Request::adjustScanCursor(long cursor)
+void Request::adjustScanCursor(__uint128_t cursor)
 {
-    char buf[32];
-    int n = snprintf(buf, sizeof(buf), "%ld", cursor);
+    char buf[64];  // 128-bit integer needs at most 39 decimal digits
+    int n = Util::uint128ToString(cursor, buf);
     if (mHead.empty()) {
         SegmentStr<64> str(mReq);
         const char* p = strchr(str.data(), '$');

--- a/src/Request.h
+++ b/src/Request.h
@@ -63,7 +63,7 @@ public:
     void setSentinels(const String& master);
     void setSentinelGetMaster(const String& master);
     void setSentinelSlaves(const String& master);
-    void adjustScanCursor(long cursor);
+    void adjustScanCursor(__uint128_t cursor);
     void follow(Request* leader);
     void setResponse(Response* res);
     bool send(Socket* s);

--- a/src/Util.h
+++ b/src/Util.h
@@ -81,6 +81,31 @@ namespace Util
     {
         return duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count();
     }
+    
+    // Convert 128-bit unsigned integer to string
+    // Returns the length of the converted string (excluding null terminator)
+    // The buffer must be at least 40 bytes (39 digits + null terminator for max __uint128_t value)
+    inline int uint128ToString(__uint128_t value, char* buf)
+    {
+        int n = 0;
+        if (value == 0) {
+            buf[n++] = '0';
+        } else {
+            char temp[64];
+            int tempLen = 0;
+            __uint128_t v = value;
+            while (v > 0) {
+                temp[tempLen++] = '0' + (v % 10);
+                v /= 10;
+            }
+            // Reverse digits (extracted from low to high)
+            for (int i = tempLen - 1; i >= 0; i--) {
+                buf[n++] = temp[i];
+            }
+        }
+        buf[n] = '\0';
+        return n;
+    }
 };
 
 #endif


### PR DESCRIPTION
## Background
When Predixy runs in Cluster mode (e.g., with Kvrocks), it encodes the backend SCAN cursor together with the Server Group ID so a single client-side cursor can scan across groups. Kvrocks may return very large cursors due to its RocksDB iterator state.
## Problem
SCAN loops never complete (cursor never returns to 0).
Monitor shows steadily increasing cursors being sent to the backend.
## Root Cause
Predixy encodes the client-visible cursor as: clientCursor = (backendCursor << 10) | groupId.
Kvrocks cursors can be close to 2^64, and the left-shift by 10 pushes the value beyond 64-bit limits.
Using 64-bit integers causes overflow on shift, corrupting both the cursor and the embedded group ID, which leads to incorrect routing and an endless scan loop.
## Fix
Use 128-bit integers (__uint128_t) to safely parse, encode, and decode SCAN cursors.
Manually convert between strings and 128-bit integers (standard printf/stringstream do not support __uint128_t).
Preserve the existing 10-bit group encoding scheme.
## Implementation
src/Handler.cpp:
Request path: parse client cursor as __uint128_t, extract group via mask, derive backend cursor via right shift.
Response path: parse backend cursor as __uint128_t, left shift by 10, OR with group ID, then serialize to string.
Add debug logs tracing client/server cursors and group IDs.
src/Request.h:
Change signature: void adjustScanCursor(__uint128_t cursor);
src/Request.cpp:
Implement adjustScanCursor with manual 128-bit-to-string conversion.
## Compatibility and Performance
Requires compiler support for __uint128_t (GCC ≥ 4.6 or Clang ≥ 3.0).
Negligible CPU overhead; minor memory increase per cursor (16 bytes vs 8).
Cursor strings may be longer over the wire; functional impact is minimal.
## Testing and Verification
Run SCAN from a client through Predixy against Kvrocks in Cluster mode:
Cursor advances with large decimal values and eventually returns "0".
All keys are visited without duplication.
Enable Debug logs to verify:
Correct client → server decode (group extraction, right shift).
Correct server → client encode (left shift, OR group).
Final cursor "0" round trip.